### PR TITLE
Bugfix sampletype

### DIFF
--- a/Source/sfont.cpp
+++ b/Source/sfont.cpp
@@ -244,14 +244,12 @@ bool SoundFont::read()
                 readSection(fourcc, len3);
             }
         }
-        // load sample data
-        for (int i = 0; i < _samples.size(); i++)
-            readSampleData(_samples[i]);
-
 #if FIX_INVALID_SAMPLETYPE
         fixSampleType();
 #endif
-
+        // load sample data
+        for (int i = 0; i < _samples.size(); i++)
+            readSampleData(_samples[i]);
     }
     catch (juce::String s) {
         log(s);
@@ -1684,42 +1682,35 @@ int SoundFont::writeSampleDataFlac (Sample* s, int quality)
 
 void SoundFont::fixSampleType()
 {
+    int flag = 0xf;
     for (int i = 0; i < _samples.size(); i++) {
-        Sample * s = _samples[i];
-        switch (s->sampletype & 15) {
-            case 3:
-                s->sampletype &= ~15;
-                switch (_fileFormatIn) {
-                    case SF3Format:
-                        s->sampletype |= 2;
-                        break;
-
-                    case SF4Format:
-                        s->sampletype |= 1;
-                        break;
-
-                    default:
-                        break;
+        flag &= _samples[i]->sampletype;
+    }
+    switch (flag) {
+        case 1:
+            if (_fileFormatIn != SF2Format)
+            {
+                for (int i = 0; i < _samples.size(); i++) {
+                    if (_samples[i]->sampletype != 1) {
+                        _samples[i]->sampletype &= ~1;
+                    }
+                    _samples[i]->sampletype |= SampleType::TypeVorbis;
                 }
-                break;
-
-            case 5:
-            case 6:
-            case 7:
-                s->sampletype &= ~15;
-                s->sampletype |= 4;
-                break;
-
-            case 9:
-            case 10:
-            case 11:
-                s->sampletype &= ~15;
-                s->sampletype |= 8;
-                break;
-
-            default:
-                break;
+            }
+            break;
+        case 2:
+        case 3:
+        {
+            for (int i = 0; i < _samples.size(); i++) {
+                if (_samples[i]->sampletype != 2) {
+                    _samples[i]->sampletype &= ~2;
+                }
+                _samples[i]->sampletype |= SampleType::TypeFlac;
+            }
         }
+            break;
+        default:
+            break;
     }
 }
 #endif

--- a/Source/sfont.cpp
+++ b/Source/sfont.cpp
@@ -93,11 +93,11 @@ void Sample::setCompressionType (SampleCompression c)
     {
         case SampleCompression::Vorbis :
             sampletype &= ~((int)(SampleType::TypeVorbis + SampleType::TypeFlac));
-            sampletype |= SampleType::TypeVorbis;
+            sampletype |= (int)SampleType::TypeVorbis;
             break;
         case SampleCompression::Flac :
             sampletype &= ~((int)(SampleType::TypeVorbis + SampleType::TypeFlac));
-            sampletype |= SampleType::TypeFlac;
+            sampletype |= (int)SampleType::TypeFlac;
             break;
         case SampleCompression::Raw :
             sampletype &= ~((int)(SampleType::TypeVorbis + SampleType::TypeFlac));

--- a/Source/sfont.cpp
+++ b/Source/sfont.cpp
@@ -92,8 +92,12 @@ void Sample::setCompressionType (SampleCompression c)
     switch (c)
     {
         case SampleCompression::Vorbis :
+            sampletype &= ~((int)(SampleType::TypeVorbis + SampleType::TypeFlac));
+            sampletype |= SampleType::TypeVorbis;
+            break;
         case SampleCompression::Flac :
-            sampletype |= (int)c;
+            sampletype &= ~((int)(SampleType::TypeVorbis + SampleType::TypeFlac));
+            sampletype |= SampleType::TypeFlac;
             break;
         case SampleCompression::Raw :
             sampletype &= ~((int)(SampleType::TypeVorbis + SampleType::TypeFlac));

--- a/Source/sfont.cpp
+++ b/Source/sfont.cpp
@@ -1705,12 +1705,14 @@ void SoundFont::fixSampleType()
 
             case 5:
             case 6:
+            case 7:
                 s->sampletype &= ~15;
                 s->sampletype |= 4;
                 break;
 
             case 9:
             case 10:
+            case 11:
                 s->sampletype &= ~15;
                 s->sampletype |= 8;
                 break;

--- a/Source/sfont.cpp
+++ b/Source/sfont.cpp
@@ -247,6 +247,11 @@ bool SoundFont::read()
         // load sample data
         for (int i = 0; i < _samples.size(); i++)
             readSampleData(_samples[i]);
+
+#if FIX_INVALID_SAMPLETYPE
+        fixSampleType();
+#endif
+
     }
     catch (juce::String s) {
         log(s);
@@ -1670,6 +1675,52 @@ int SoundFont::writeSampleDataFlac (Sample* s, int quality)
     return numBytes;
 }
 
+
+
+#if FIX_INVALID_SAMPLETYPE
+//---------------------------------------------------------
+//   fixSampleType
+//---------------------------------------------------------
+
+void SoundFont::fixSampleType()
+{
+    for (int i = 0; i < _samples.size(); i++) {
+        Sample * s = _samples[i];
+        switch (s->sampletype & 15) {
+            case 3:
+                s->sampletype &= 15;
+                switch (_fileFormatIn) {
+                    case SF3Format:
+                        s->sampletype |= 2;
+                        break;
+
+                    case SF4Format:
+                        s->sampletype |= 1;
+                        break;
+
+                    default:
+                        break;
+                }
+                break;
+
+            case 5:
+            case 6:
+                s->sampletype &= 15;
+                s->sampletype |= 4;
+                break;
+
+            case 9:
+            case 10:
+                s->sampletype &= 15;
+                s->sampletype |= 8;
+                break;
+
+            default:
+                break;
+        }
+    }
+}
+#endif
 
 
 #if 0

--- a/Source/sfont.cpp
+++ b/Source/sfont.cpp
@@ -1688,7 +1688,7 @@ void SoundFont::fixSampleType()
         Sample * s = _samples[i];
         switch (s->sampletype & 15) {
             case 3:
-                s->sampletype &= 15;
+                s->sampletype &= ~15;
                 switch (_fileFormatIn) {
                     case SF3Format:
                         s->sampletype |= 2;
@@ -1705,13 +1705,13 @@ void SoundFont::fixSampleType()
 
             case 5:
             case 6:
-                s->sampletype &= 15;
+                s->sampletype &= ~15;
                 s->sampletype |= 4;
                 break;
 
             case 9:
             case 10:
-                s->sampletype &= 15;
+                s->sampletype &= ~15;
                 s->sampletype |= 8;
                 break;
 

--- a/Source/sfont.h
+++ b/Source/sfont.h
@@ -33,6 +33,9 @@
 // Enable this, if compression format is set individually per sample (not yet possible)
 #define USE_MULTIPLE_COMPRESSION_FORMATS 0
 
+// Disable this, if you don't want to fix invalid sampletype.
+#define FIX_INVALID_SAMPLETYPE 1
+
 #ifndef byte
 typedef unsigned char byte;
 #endif
@@ -381,6 +384,10 @@ private:
     
     bool writeCSample (Sample*, int idx);
     
+#if FIX_INVALID_SAMPLETYPE
+    void fixSampleType();
+#endif
+
 #if ! USE_JUCE_VORBIS
     bool decodeOggVorbis (Sample* s);
 #endif


### PR DESCRIPTION
Fixes #1 and added fixing sampletype function.
Note: A file which is converted from SF3 to SF4 or from SF4 to SF3 may be not fixed.